### PR TITLE
Add XML documentation for default instance properties in complex value objects

### DIFF
--- a/src/Thinktecture.Runtime.Extensions.SourceGenerator/CodeAnalysis/ValueObjects/ComplexValueObjectCodeGenerator.cs
+++ b/src/Thinktecture.Runtime.Extensions.SourceGenerator/CodeAnalysis/ValueObjects/ComplexValueObjectCodeGenerator.cs
@@ -85,6 +85,9 @@ namespace ").Append(_state.Namespace).Append(@"
       {
          _sb.Append(@"
 
+      /// <summary>
+      /// Default instance of ").AppendTypeForXmlComment(_state).Append(@".
+      /// </summary>
       public static readonly ").AppendTypeFullyQualified(_state).Append(" ").Append(_state.Settings.DefaultInstancePropertyName).Append(" = default;");
       }
 

--- a/test/Thinktecture.Runtime.Extensions.SourceGenerator.Tests/SourceGeneratorTests/ValueObjectSourceGeneratorTests.Should_generate_complex_struct_with_custom_default_instance_property_name.verified.txt
+++ b/test/Thinktecture.Runtime.Extensions.SourceGenerator.Tests/SourceGeneratorTests/ValueObjectSourceGeneratorTests.Should_generate_complex_struct_with_custom_default_instance_property_name.verified.txt
@@ -25,6 +25,9 @@ namespace Thinktecture.Tests
 
       private static readonly int _typeHashCode = typeof(global::Thinktecture.Tests.TestValueObject).GetHashCode();
 
+      /// <summary>
+      /// Default instance of <see cref="TestValueObject"/>.
+      /// </summary>
       public static readonly global::Thinktecture.Tests.TestValueObject Null = default;
 
       /// <summary>


### PR DESCRIPTION
When defining DefaultInstancePropertyName for ComplexValueObjectAttribute the generated default instance has no xml doc.
It however works fine for the ValueObject attribute so it seems like it has just been forgotten.