### PR TITLE
Skip TTRESG104 diagnostic for interface properties

### DIFF
--- a/src/Thinktecture.Runtime.Extensions.SourceGenerator/CodeAnalysis/Diagnostics/ThinktectureRuntimeExtensionsAnalyzer.cs
+++ b/src/Thinktecture.Runtime.Extensions.SourceGenerator/CodeAnalysis/Diagnostics/ThinktectureRuntimeExtensionsAnalyzer.cs
@@ -251,6 +251,7 @@ public sealed class ThinktectureRuntimeExtensionsAnalyzer : DiagnosticAnalyzer
           || context.ContainingSymbol is not IPropertySymbol propertySymbol
           || propertySymbol.SetMethod is null // public MyStruct Member { get; }
           || propertySymbol.IsStatic
+          || propertySymbol.ContainingType.TypeKind == TypeKind.Interface                                          // interfaces cannot have required members
           || propertySymbol.DeclaredAccessibility < propertySymbol.ContainingType.DeclaredAccessibility            // required members must not be less visible than the containing type
           || propertySymbol.SetMethod.DeclaredAccessibility < propertySymbol.ContainingType.DeclaredAccessibility) // setter of required members must not be less visible than the containing type
          return;

--- a/test/Thinktecture.Runtime.Extensions.SourceGenerator.Tests/AnalyzerAndCodeFixTests/TTRESG104_MembersDisallowingDefaultValuesMustBeRequired.cs
+++ b/test/Thinktecture.Runtime.Extensions.SourceGenerator.Tests/AnalyzerAndCodeFixTests/TTRESG104_MembersDisallowingDefaultValuesMustBeRequired.cs
@@ -188,6 +188,27 @@ public class TTRESG104_MembersDisallowingDefaultValuesMustBeRequired
       }
 
       [Fact]
+      public async Task Should_not_trigger_on_interface_property()
+      {
+         var code = """
+
+            using System;
+            using Thinktecture;
+            using Thinktecture.Runtime.Tests.TestValueObjects;
+
+            namespace TestNamespace
+            {
+               public interface IMyInterface
+               {
+                  IntBasedStructValueObjectDoesNotAllowDefaultStructs DisallowingProperty { get; set; }
+               }
+            }
+            """;
+
+         await Verifier.VerifyAnalyzerAsync(code, [typeof(ValueObjectAttribute<>).Assembly, typeof(IntBasedStructValueObjectDoesNotAllowDefaultStructs).Assembly]);
+      }
+
+      [Fact]
       public async Task Should_not_trigger_on_special_type_property()
       {
          var code = """


### PR DESCRIPTION
Interfaces cannot have `required` members in C#, so the diagnostic
(and its code fix) should not fire for properties declared in interfaces.

https://claude.ai/code/session_01GfG47CpoCK1fMQ3E5D9wR6